### PR TITLE
git checkout --pr and some other improvements

### DIFF
--- a/client.py
+++ b/client.py
@@ -72,10 +72,9 @@ async def _load_extension(ctx, extension, path='cogs'):
     except (commands.ExtensionAlreadyLoaded, commands.ExtensionNotFound) as e:
         if isinstance(e, commands.ExtensionAlreadyLoaded):
             await ctx.send(f"<:github:772040411954937876>  This extension is **already loaded!**")
-            return
         elif isinstance(e, commands.ExtensionNotFound):
             await ctx.send(f"<:github:772040411954937876>  I couldn't find that extension!")
-            return
+        return
     await ctx.send(f"<:github:772040411954937876>  **{extension}** extension has been **loaded.**")
 
 
@@ -92,10 +91,9 @@ async def _unload_extension(ctx, extension, path='cogs'):
     except (commands.ExtensionNotLoaded, commands.ExtensionNotFound) as e:
         if isinstance(e, commands.ExtensionNotLoaded):
             await ctx.send(f"<:github:772040411954937876>  This extension **isn't loaded!**")
-            return
         elif isinstance(e, commands.ExtensionNotFound):
             await ctx.send(f"<:github:772040411954937876>  I couldn't find that extension!")
-            return
+        return
     await ctx.send(f"<:github:772040411954937876>  **{extension}** extension has been **unloaded.**")
 
 
@@ -112,10 +110,9 @@ async def _reload_extension(ctx, extension, path='cogs'):
     except (commands.ExtensionNotLoaded, commands.ExtensionNotFound) as e:
         if isinstance(e, commands.ExtensionNotLoaded):
             await ctx.send(f"<:github:772040411954937876>  This extension **isn't loaded!**")
-            return
         elif isinstance(e, commands.ExtensionNotFound):
             await ctx.send(f"<:github:772040411954937876>  I couldn't find that extension!")
-            return
+        return
     await ctx.send(f"<:github:772040411954937876> **{extension}** extension has been **reloaded.**")
 
 

--- a/cogs/checkout.py
+++ b/cogs/checkout.py
@@ -8,6 +8,11 @@ from datetime import datetime
 
 Git = globals.Git
 html_comment_regex = re.compile(r'<!--.*-->', re.MULTILINE | re.DOTALL)
+PR_STATES: dict = {
+    "open": "<:pr_open:795793711312404560>",
+    "closed": "<:pr_closed:788518707969785886>",
+    "merged": "<:merge:795801508146839612>"
+}
 
 
 def kill_markdown(text: str) -> str:
@@ -343,13 +348,12 @@ class Checkout(commands.Cog):
             await ctx.send(f"{self.e}  The second argument must be an issue **number!**")
             return
         issue = await Git.get_issue(repo, int(issue_number))
-        if type(issue) is str:
+        if isinstance(issue, str):
             if issue == 'repo':
                 await ctx.send(f"{self.e}  This repository **doesn't exist!**")
-                return
             else:
                 await ctx.send(f"{self.e}  An issue with this number **doesn't exist!**")
-                return
+            return
         em: str = f"<:issue_open:788517560164810772>"
         if issue['state'].lower() == 'closed':
             em: str = '<:issue_closed:788517938168594452>'
@@ -362,12 +366,12 @@ class Checkout(commands.Cog):
         if all(['body' in issue, issue['body'], len(issue['body'])]):
             body: Union[str, None] = str(issue['body']).strip()
             if len(body) > 512:
-                body: str = re.sub(html_comment_regex, '', body).replace('#', '')[:512]  # Kill comments
-                body: str = kill_markdown(f"{body[:body.rindex(' ')]}...".strip())  # Kill markdown
+                body: str = body[:512]
+                body: str = f"{body[:body.rindex(' ')]}...".strip()
         else:
             body = None
         if body:
-            embed.add_field(name=':scroll: Body:', value=f"```{body}```", inline=False)
+            embed.add_field(name=':notepad_spiral: Body:', value=f"```{body}```", inline=False)
 
         created_at: datetime = datetime.strptime(issue['createdAt'], '%Y-%m-%dT%H:%M:%SZ')
 
@@ -389,6 +393,9 @@ class Checkout(commands.Cog):
         comments: str = f"Has {issue['commentCount']} comments"
         if issue['commentCount'] == 1:
             comments: str = "Has only one comment"
+        elif issue['commentCount'] == 0:
+            comments: str = "Has no comments"
+
         comments_and_assignees: str = f"{comments} and {assignees}"
 
         participants: str = f"\n{issue['participantCount']} people have participated in this issue" if \
@@ -402,6 +409,104 @@ class Checkout(commands.Cog):
             embed.add_field(name=':label: Labels:', value=' '.join([f"`{lb}`" for lb in issue['labels']]))
 
         embed.set_thumbnail(url=issue['author']['avatarUrl'])
+        await ctx.send(embed=embed)
+
+    @checkout.command(name='--pr', aliases=['--pull', '-pr', 'pr', '--pullrequest', '-pull'])
+    @commands.cooldown(10, 30, commands.BucketType.user)
+    @guild_available()
+    async def pull_request_command(self, ctx: commands.Context, repo: str, pr_number: str):
+        if not pr_number.isnumeric():
+            await ctx.send(f"{self.e}  The second argument must be a pull request **number!**")
+            return
+        pr: dict = await Git.get_pull_request(repo, int(pr_number))
+        if isinstance(pr, str):
+            if pr == 'repo':
+                await ctx.send(f"{self.e}  This repository **doesn't exist!**")
+            else:
+                await ctx.send(f"{self.e}  A pull request with this number **doesn't exist!**")
+            return
+
+        title: str = pr['title'] if len(pr['title']) <= 90 else f"{pr['title'][:87]}..."
+        state = pr['state'].lower().capitalize()
+        embed: discord.Embed = discord.Embed(
+            title=f"{PR_STATES[state.lower()]}  {title} #{pr_number}",
+            url=pr['url'],
+            color=0xefefef,
+            description=None
+        )
+        embed.set_thumbnail(url=pr['author']['avatarUrl'])
+        if all(['bodyText' in pr and pr['bodyText'], len(pr['bodyText'])]):
+            body = pr['bodyText']
+            if len(body) > 390:
+                body: str = body[:387]
+                body: str = f"{body[:body.rindex(' ')]}...".strip()
+            embed.add_field(name=':notepad_spiral: Body:', value=f"```{body}```", inline=False)
+
+        created_at: datetime = datetime.strptime(pr['createdAt'], '%Y-%m-%dT%H:%M:%SZ')
+        user: str = f"Created by [{pr['author']['login']}]({pr['author']['url']}) on {created_at.strftime('%e, %b %Y')}"
+
+        if pr['closed']:
+            closed_at: datetime = datetime.strptime(pr['closedAt'], '%Y-%m-%dT%H:%M:%SZ')
+            closed: str = f"\nClosed on {closed_at.strftime('%e, %b %Y')}\n"
+        else:
+            closed: str = '\n'
+
+        reviews: str = f"{pr['reviews']['totalCount']} reviews"
+        if pr['reviews']['totalCount'] == 1:
+            reviews: str = 'one review'
+        elif pr['reviews']['totalCount'] == 0:
+            reviews: str = 'no reviews'
+
+        comments: str = f"Has {pr['comments']['totalCount']} comments"
+        if pr['comments']['totalCount'] == 1:
+            comments: str = "Has only one comment"
+        elif pr['comments']['totalCount'] == 0:
+            comments: str = 'Has no comments'
+
+        comments_and_reviews: str = f'{comments} and {reviews}\n'
+
+        commit_c: int = pr["commits"]["totalCount"]
+
+        files_changed: str = f'[{pr["changedFiles"]} files]({pr["url"]}/files) ' \
+                             f'have been changed over [{commit_c} commits]({pr["url"]}/commits)\n'
+        if pr["changedFiles"] == 1:
+            files_changed: str = f'[One file]({pr["url"]}/files) was changed ' \
+                                 f'over [{commit_c} commits]({pr["url"]}/commits)\n'
+        elif pr['changedFiles'] == 0:
+            files_changed: str = f'No files have been changed in this PR\n'
+
+        additions_deletions: str = f'Updated with {pr["additions"]} additions and {pr["deletions"]} deletions.\n'
+
+        assignee_strings = [f"- [{u[0]}]({u[1]})\n" for u in pr['assignees']['users']]
+        reviewer_strings = [f"- [{u[0]}]({u[1]})\n" for u in pr['reviewers']['users']]
+        participant_strings = [f"- [{u[0]}]({u[1]})\n" for u in pr['participants']['users']]
+
+        assignee_strings = assignee_strings if len(assignee_strings) <= 3 else assignee_strings[
+                                                                               :3] + f'- and {len(assignee_strings) - 3} more'
+
+        reviewer_strings = reviewer_strings if len(reviewer_strings) <= 3 else reviewer_strings[
+                                                                               :3] + f'- and {len(reviewer_strings) - 3} more'
+
+        participant_strings = participant_strings if len(participant_strings) <= 3 else participant_strings[
+                                                                                        :3] + f'- and {len(participant_strings)} more'
+
+        cross_repo: str = f'This pull request came from a fork.' if pr['isCrossRepository'] else ''
+        info: str = f'{user}{closed}{comments_and_reviews}{files_changed}{additions_deletions}{cross_repo}'
+        embed.add_field(name=':mag_right: Info:', value=info, inline=False)
+
+        embed.add_field(name='Participants:',
+                        value=''.join(participant_strings) if len(participant_strings) else f'No participants',
+                        inline=True)
+        embed.add_field(name='Assignees:',
+                        value=''.join(assignee_strings) if len(assignee_strings) else f'No assignees',
+                        inline=True)
+        embed.add_field(name='Reviewers:',
+                        value=''.join(reviewer_strings) if len(reviewer_strings) else f'No reviewers',
+                        inline=True)
+
+        if pr['labels']:
+            embed.add_field(name=':label: Labels:', value=' '.join([f"`{lb}`" for lb in pr['labels']]), inline=False)
+
         await ctx.send(embed=embed)
 
 

--- a/cogs/checkout.py
+++ b/cogs/checkout.py
@@ -466,16 +466,31 @@ class Checkout(commands.Cog):
         comments_and_reviews: str = f'{comments} and {reviews}\n'
 
         commit_c: int = pr["commits"]["totalCount"]
+        commits = f'[{commit_c} commits]({pr["url"]}/commits)'
+        if commit_c == 1:
+            commits = f'[one commit]({pr["url"]}/commits)'
 
         files_changed: str = f'[{pr["changedFiles"]} files]({pr["url"]}/files) ' \
-                             f'have been changed over [{commit_c} commits]({pr["url"]}/commits)\n'
+                             f'have been changed in {commits}\n'
         if pr["changedFiles"] == 1:
             files_changed: str = f'[One file]({pr["url"]}/files) was changed ' \
-                                 f'over [{commit_c} commits]({pr["url"]}/commits)\n'
+                                 f'in [{commit_c} commits]({pr["url"]}/commits)\n'
         elif pr['changedFiles'] == 0:
             files_changed: str = f'No files have been changed in this PR\n'
 
-        additions_deletions: str = f'Updated with {pr["additions"]} additions and {pr["deletions"]} deletions.\n'
+        additions: str = f'Updated with {pr["additions"]} additions'
+        if pr["additions"] == 1:
+            additions: str = 'Updated with one addition'
+        elif pr['additions'] == 0:
+            additions: str = 'Updated with no additions'
+
+        deletions: str = f'{pr["deletions"]} deletions'
+        if pr['deletions'] == 1:
+            deletions: str = 'one deletion'
+        elif pr['deletions'] == 0:
+            deletions: str = 'no deletions'
+
+        additions_and_deletions: str = f'{additions} and {deletions}.\n'
 
         assignee_strings = [f"- [{u[0]}]({u[1]})\n" for u in pr['assignees']['users']]
         reviewer_strings = [f"- [{u[0]}]({u[1]})\n" for u in pr['reviewers']['users']]
@@ -491,7 +506,7 @@ class Checkout(commands.Cog):
                                                                                         :3] + f'- and {len(participant_strings)} more'
 
         cross_repo: str = f'This pull request came from a fork.' if pr['isCrossRepository'] else ''
-        info: str = f'{user}{closed}{comments_and_reviews}{files_changed}{additions_deletions}{cross_repo}'
+        info: str = f'{user}{closed}{comments_and_reviews}{files_changed}{additions_and_deletions}{cross_repo}'
         embed.add_field(name=':mag_right: Info:', value=info, inline=False)
 
         embed.add_field(name='Participants:',

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -46,6 +46,7 @@ class Help(commands.Cog):
                        "\n**Important!** Repo commands that follow, require the exact syntax of `username/repo-name` "
                        "in place of the `{repo}` argument, ex. `itsmewulf/GitHub-Discord`",
                        "\n`--issue {repo} {issue number}` - get detailed info on an issue",
+                       "`--pr {repo} {pr number}` - get detailed info on a pull request",
                        "`--repo -info {repo}` - get info about a repository",
                        "`--repo -src {repo}` - get the repo's file structure"]
         embed = discord.Embed(

--- a/cogs/info.py
+++ b/cogs/info.py
@@ -37,14 +37,14 @@ class Info(commands.Cog):
             url=lcns["html_url"],
             description=None
         )
-        embed.add_field(name=f"Description", value=f'```{lcns["description"]}```', inline=False)
-        embed.add_field(name="Implementation", value=f'```{lcns["implementation"]}```', inline=False)
-        embed.add_field(name="Permissions", value="".join([f"{self.d1}  {x}\n" for x in lcns["permissions"]]) if len(
+        embed.add_field(name=f"Description:", value=f'```{lcns["description"]}```', inline=False)
+        embed.add_field(name="Implementation:", value=f'```{lcns["implementation"]}```', inline=False)
+        embed.add_field(name="Permissions:", value="".join([f"{self.d1}  {x}\n" for x in lcns["permissions"]]) if len(
             lcns["permissions"]) != 0 else "None")
-        embed.add_field(name="Conditions",
+        embed.add_field(name="Conditions:",
                         value="".join([f"{self.d2}  {x}\n" for x in lcns["conditions"]]) if len(
                             lcns["conditions"]) != 0 else "None")
-        embed.add_field(name="Limitations", value="".join([f"{self.d3}  {x}\n" for x in lcns["limitations"]]) if len(
+        embed.add_field(name="Limitations:", value="".join([f"{self.d3}  {x}\n" for x in lcns["limitations"]]) if len(
             lcns["limitations"]) != 0 else "None")
         await ctx.send(embed=embed)
 

--- a/core/background.py
+++ b/core/background.py
@@ -14,8 +14,6 @@ class Background(commands.Cog):
     async def status_changer(self):
         presences: cycle = cycle([Game(f"in {len(self.client.guilds)} servers"),
                                   Activity(type=ActivityType.watching, name="git --help"),
-                                  Game(
-                                      f"for {sum([x.member_count for x in self.client.guilds])} users!"),
                                   Activity(
                                       type=ActivityType.listening, name="your Git feed")])
         await self.client.change_presence(activity=next(presences))

--- a/handle/errors.py
+++ b/handle/errors.py
@@ -14,6 +14,9 @@ class Errors(commands.Cog):
         elif isinstance(error, commands.CommandOnCooldown):
             msg = self.e + " " + '**You\'re on cooldown!** Please try again in {:.2f}s'.format(error.retry_after)
             await ctx.send(msg)
+        elif isinstance(error, commands.MaxConcurrencyReached):
+            await ctx.send(
+                f"{self.e}  This command is experiencing exceptional traffic. **Please try again in a few seconds.**")
         elif not PRODUCTION:
             raise error
         else:


### PR DESCRIPTION
## Summary
In this PR, I mostly focused on implementing the `git checkout --pr` command. Aside from that I fixed some codefactor issues and made the `git --dl` command faster and more reliable with a concurrency limiter and quicker fail-time.

## Notes
TrustedMercury suggested defaulting to the saved repo if only a PR/issue number is passed. I think that is a good idea and I will be implementing that in the near future.
