### PR TITLE
v3.2.0

### DIFF
--- a/cogs/ecosystem/config.py
+++ b/cogs/ecosystem/config.py
@@ -71,12 +71,8 @@ class Config(commands.Cog):
                 await ctx.error(ctx.l.generic.nonexistent.qa)
                 return
             lang: str = ctx.fmt('accessibility list locale', f'`{ctx.l.meta.localized_name.capitalize()}`')
-            user_str: str = ctx.fmt('qa list user', (f'[`{user["user"]}`](https://github.com/{user["user"]})'
-                                                     if 'user' in user else f'`{ctx.l.config.show.base.item_not_set}`'))
-            org: str = ctx.fmt('qa list org', (f'[`{user["org"]}`](https://github.com/{user["org"]})'
-                                               if 'org' in user else f'`{ctx.l.config.show.base.item_not_set}`'))
-            repo: str = ctx.fmt('qa list repo', (f'[`{user["repo"]}`](https://github.com/{user["repo"]})'
-                                                 if 'repo' in user else f'`{ctx.l.config.show.base.item_not_set}`'))
+            user_str, org, repo = (ctx.fmt(f'qa list {item}', f'[`{item}`](https://github.com/{item})' if item in user else
+                                           f'`{ctx.l.config.show.base.item_not_set}`') for item in ('user', 'org', 'repo'))
             accessibility: list = ctx.l.config.show.base.accessibility.heading + '\n' + '\n'.join([lang])
             qa: list = ctx.l.config.show.base.qa.heading + '\n' + '\n'.join([user_str, org, repo])
             guild_str: str = ''
@@ -90,7 +86,7 @@ class Config(commands.Cog):
                     ac: AutomaticConversionSettings = Mgr.env.autoconv_default
                 else:
                     ac: AutomaticConversionSettings = {k: (v if k not in (_ac := guild.get('autoconv', {}))
-                                               else _ac[k]) for k, v in Mgr.env.autoconv_default.items()}
+                                                       else _ac[k]) for k, v in Mgr.env.autoconv_default.items()}
                 codeblock: str = ctx.fmt('codeblock',
                                          f'`{ctx.l.enum.generic.switch[str(ac["codeblock"])]}`')
                 lines: str = ctx.fmt('gh_lines',

--- a/lib/api/github.py
+++ b/lib/api/github.py
@@ -44,7 +44,7 @@ class GitHubAPI:
     """
 
     def __init__(self, tokens: tuple, requester: str):
-        requester: str = requester + '; Python {v.major}.{v.minor}.{v.micro}'.format(v=version_info)
+        requester += '; Python {v.major}.{v.minor}.{v.micro}'.format(v=version_info)
         self.__tokens: tuple = tokens
         self.__token_cycle: cycle = cycle(t for t in self.__tokens if t is not None)
         self.queries: DirProxy = DirProxy('./resources/queries/', ('.gql', '.graphql'))

--- a/lib/api/github.py
+++ b/lib/api/github.py
@@ -107,7 +107,7 @@ class GitHubAPI:
             return []
 
     @normalize_repository
-    async def get_tree_file(self, repo: GitHubRepository, path: str):
+    async def get_tree_file(self, repo: GitHubRepository, path: str) -> dict | list:
         if repo.count('/') != 1:
             return []
         if path[0] == '/':

--- a/lib/typehints/__init__.py
+++ b/lib/typehints/__init__.py
@@ -7,6 +7,7 @@ from lib.typehints.db.guild.autoconv import AutomaticConversionSettings
 from lib.typehints.generic import *
 from lib.typehints.locale.help import *
 from lib.typehints.db.guild.release_feed import *
+from lib.typehints.gitbot_dot_json import *
 
 __all__: tuple = (
     'DictSequence',

--- a/lib/typehints/gitbot_dot_json.py
+++ b/lib/typehints/gitbot_dot_json.py
@@ -1,0 +1,14 @@
+from typing import TypedDict
+
+
+class LOCGitBotJSONEntry(TypedDict):
+    ignore: str | list[str]
+
+
+class ReleaseFeedGitBotJSONEntry(TypedDict):
+    ignore: str
+
+
+class GitBotDotJSON(TypedDict, total=False):
+    loc: LOCGitBotJSONEntry
+    release_feed: ReleaseFeedGitBotJSONEntry

--- a/resources/locale/en.locale.json
+++ b/resources/locale/en.locale.json
@@ -399,7 +399,13 @@
       "comments": "Comments",
       "detailed": "Detailed"
     },
-    "footer": "This command is powered by the CLOC CLI tool."
+    "footer": {
+      "with_count": {
+        "plural": "{0} entries matching .gitbot.json ignore rules were removed.",
+        "singular": "One entry matching .gitbot.json ignore rules was removed."
+      },
+      "credit": "This command is powered by the CLOC CLI tool."
+    }
   },
   "commits": {
     "embed": {


### PR DESCRIPTION
## Summary
Some files and directories shouldn't count towards the line count shown in the `git loc` command - that's what this update addresses!

## Details
As a repository collaborator/owner you can now create a JSON file named `.gitbot.json` at the root of your repo, which will allow you to ignore files and directories which you don't want to be included using [fnmatch](https://docs.python.org/3/library/fnmatch.html) patterns:
```json
{
	"loc": {
		"ignore": "*.ignored.extension"
	}
}
```

**or**

```json
{
	"loc": {
		"ignore": ["*.ignored.extension", "lib/", "*.py[!cod]"]
	}
}
```

### More on [fnmatch](https://docs.python.org/3/library/fnmatch.html)
`fnmatch` is a Python module that powers this GitBot feature. It's similar to the `.gitignore` syntax which you know and love.  
In `fnmatch` the following wildcards can be used:  

<table>
<th>Pattern</th>
<th>Meaning</th>
<tr>
	<td>*</td>
	<td>matches everything</td>
<tr>
	<td>?</td>
	<td>matches any single character</td>
<tr>
	<td>[seq]</td>
	<td>matches any character in seq</td>
<tr>
	<td>[!seq]</td>
	<td>matches any character not in seq</td>
</table>

## Notes
The introduction of the `.gitbot.json` config spec opens the door for many fantastic features to be implemented in the future.
