### PR TITLE
Select-menu-based commit and gist commands + advanced formatting

### DIFF
--- a/cogs/ecosystem/help.py
+++ b/cogs/ecosystem/help.py
@@ -101,7 +101,7 @@ class Help(commands.Cog):
             pages + embed
         await pages.start(ctx)
 
-    @gitbot_hybrid_command('help', aliases=['h', 'halp' 'commands', 'cmds', 'cmd', 'cmdslist', 'cmdlist', 'cmds-list', 'cmd-list'])
+    @gitbot_hybrid_command('help', aliases=['h', 'halp' 'commands', 'cmds', 'cmd', 'cmdslist', 'cmdlist', 'cmds-list', 'cmd-list'], description='Get information about GitBot\'s commands.')
     @app_commands.rename(command_or_group='command')
     @app_commands.describe(
             command_or_group='The command you want to get help for. If omitted, the default help page will be shown.'

--- a/lib/manager.py
+++ b/lib/manager.py
@@ -16,6 +16,7 @@ import ast
 import json
 import dotenv
 import base64
+import asyncio
 import discord
 import zipfile
 import os.path
@@ -468,6 +469,20 @@ class Manager:
         if isinstance(mention, str):
             return f'@{mention}'
         return f'<@&{mention}>'
+
+    @staticmethod
+    async def just_run(func: Callable, *args, **kwargs) -> Any:
+        """
+        Run a function without a care in the world about whether it's async or not
+
+        :param func: The function to run
+        :param args: The function's positional arguments
+        :param kwargs: The function's keyword arguments
+        """
+
+        if asyncio.iscoroutinefunction(func):
+            return await func(*args, **kwargs)
+        return func(*args, **kwargs)
 
     def _setup_db(self) -> None:
         """

--- a/resources/locale/en.locale.json
+++ b/resources/locale/en.locale.json
@@ -322,13 +322,8 @@
       "no_comments": "no comments"
     },
     "no_list": "You didn't see the gist list because this user has only one gist.",
-    "footer": "Ten latest gists from {0}.\nTo inspect a specific gist, simply send its number in this channel.",
-    "index_error": "Please pick a number **between 1 and {0}**",
-    "content_notice": "The content is a preview of the first file of the gist",
-    "timeout": {
-      "title": "Timed Out",
-      "tip": "To pick an option, simply send a number next time!"
-    }
+    "footer": "Ten latest gists from {0}.\nTo inspect a specific gist, simply select it in the dropdown.",
+    "content_notice": "The content is a preview of the first file of the gist"
   },
   "issue": {
     "glossary": [


### PR DESCRIPTION
## Summary
Adds select menus to the `git repo commits` and `git gist` commands, making use of a new extended formatter. 
Also removes redundant checks in EmbedPages that were causing unnecessary errors.
