### PR TITLE
feat: release feed backlog fetching

### DIFF
--- a/cogs/backend/workers/release_feed.py
+++ b/cogs/backend/workers/release_feed.py
@@ -65,7 +65,7 @@ class ReleaseFeedWorker(commands.Cog):
                                guild: GitBotGuild,
                                repo: ReleaseFeedRepo,
                                rfi: ReleaseFeedItem,
-                               new_release: dict) -> None:
+                               new_release: dict, no_mention: bool = False) -> None:
         stage: str = 'prerelease' if new_release['release']['isPrerelease'] else 'release'
         if new_release['release']['isDraft']:
             stage += ' draft'
@@ -91,7 +91,7 @@ class ReleaseFeedWorker(commands.Cog):
         embed.add_field(name=':notepad_spiral: Body:', value=body, inline=False)
         embed.add_field(name=':mag_right: Info:', value=info)
         await self.send_to_rfi(guild, rfi, embed,
-                               self.bot.mgr.release_feed_mention_to_actual(rfi['mention']) if rfi.get('mention') else None)
+                               self.bot.mgr.release_feed_mention_to_actual(rfi['mention']) if rfi.get('mention') and not no_mention else None)
 
     async def handle_missing_feed_repo(self, guild: GitBotGuild, rfi: ReleaseFeedItem, repo: ReleaseFeedRepo) -> None:
         embed: discord.Embed = discord.Embed(

--- a/lib/api/github/transformations.py
+++ b/lib/api/github/transformations.py
@@ -37,11 +37,14 @@ def transform_repo(repo_dict: _Transformable) -> _Transformable:
 
 def transform_latest_release(release_dict: _Transformable) -> _Transformable:
     release_dict = release_dict['repository']
-    release_dict['release'] = release_dict['latestRelease'] if release_dict['latestRelease'] else None
+    release_dict['release'] = release_dict['latestRelease'] if release_dict.get('latestRelease') else None  # .get for parity with backlog fetching
     release_dict['color'] = int(release_dict['primaryLanguage']['color'][1:], 16) if release_dict[
         'primaryLanguage'] else 0x2f3136
-    del release_dict['primaryLanguage']
-    del release_dict['latestRelease']
+    try:   # parity with backlog fetching
+        del release_dict['primaryLanguage']
+        del release_dict['latestRelease']
+    except KeyError:
+        pass
     return release_dict
 
 

--- a/lib/structs/discord/components/__init__.py
+++ b/lib/structs/discord/components/__init__.py
@@ -3,4 +3,4 @@ from .embed_pages_control import EmbedPagesControlView
 from .view_file import ViewFileButton
 from .github_lines_view import GitHubLinesView
 from .confirmation import ConfirmationView
-
+from .feed_backlog_view import ReleaseFeedBacklogView

--- a/lib/structs/discord/components/feed_backlog_view.py
+++ b/lib/structs/discord/components/feed_backlog_view.py
@@ -1,0 +1,84 @@
+import discord
+from typing import TYPE_CHECKING, Callable, Any, Coroutine
+
+if TYPE_CHECKING:
+    from lib.typehints.db.guild.release_feed import ReleaseFeedRepo, ReleaseFeedItem
+    from lib.structs import GitBotContext
+
+__all__: tuple = ('ReleaseFeedBacklogView',)
+
+
+class ReleaseFeedBacklogView(discord.ui.View):
+    def __init__(self, ctx: 'GitBotContext', rfi: 'ReleaseFeedItem', rfr: 'ReleaseFeedRepo', timeout: int = 180):
+        super().__init__(timeout=timeout)
+        self.ctx = ctx
+        self.rfi, self.rfr = rfi, rfr
+        self.add_item(_FetchReleaseFeedBacklogButton(ctx=ctx))
+        self.fetch_btn = self.children[0]
+
+
+class _FetchReleaseFeedBacklogButton(discord.ui.Button):
+    view: 'ReleaseFeedBacklogView'
+
+    def __init__(self, ctx: 'GitBotContext'):
+        self.ctx = ctx
+        super().__init__(label=self.ctx.l.config.feed.repo.backlog.button.label, row=0)
+
+    async def callback(self, interaction: discord.Interaction):
+        if interaction.user.id != self.ctx.author.id or self.disabled:
+            return
+
+        async def _closing_hook():  # close everything up so that we don't get double interactions
+            self.disabled = True
+            await interaction.message.edit(view=None)
+            await interaction.delete_original_response()
+
+        await interaction.response.send_message(self.ctx.l.config.feed.repo.backlog.how_many, ephemeral=True,
+                                                view=_ReleaseFeedBacklogWantedView(self.ctx, self.view.rfi,
+                                                                                   self.view.rfr, self.view,
+                                                                                   _closing_hook))
+
+
+class _ReleaseFeedBacklogWantedView(discord.ui.View):
+    def __init__(self, ctx: 'GitBotContext', rfi: 'ReleaseFeedItem', rfr: 'ReleaseFeedRepo',
+                 orig_view: 'ReleaseFeedBacklogView', after_hook: Callable[..., Coroutine[Any, Any, None]]):
+        super().__init__(timeout=orig_view.timeout)
+        self.ctx = ctx
+        self.rfi, self.rfr = rfi, rfr
+        self.orig_view = orig_view
+        self.after_hook = after_hook
+        self.add_item(_FetchReleaseFeedBacklogSelectMenu(ctx=ctx))
+
+
+class _FetchReleaseFeedBacklogSelectMenu(discord.ui.Select):
+    view: '_ReleaseFeedBacklogWantedView'
+
+    def __init__(self, ctx: 'GitBotContext'):
+        self.ctx = ctx
+        options: list[discord.SelectOption] = [
+            discord.SelectOption(description=self.ctx.l.config.feed.repo.backlog.select.options.one,
+                                 emoji=self.ctx.bot.mgr.e.digits.pixel.one, label='1', value='1'),
+            discord.SelectOption(description=self.ctx.l.config.feed.repo.backlog.select.options.five,
+                                 emoji=self.ctx.bot.mgr.e.digits.pixel.five, label='5', value='5'),
+            discord.SelectOption(description=self.ctx.l.config.feed.repo.backlog.select.options.ten,
+                                 emoji=self.ctx.bot.mgr.e.digits.pixel.ten, label='10', value='10')
+        ]
+
+        super().__init__(placeholder=self.ctx.l.config.feed.repo.backlog.select.placeholder, options=options)
+
+    async def callback(self, interaction: discord.Interaction):
+        await interaction.response.send_message(self.ctx.bot.mgr.e.dot_sep + '  ' +
+                                                self.ctx.l.config.feed.repo.backlog.fetching, ephemeral=True)
+        n: int = await self.view.ctx.bot.mgr.handle_backlog_request(self.ctx, self.view.rfi, self.view.rfr,
+                                                                    int(self.values[0]))
+        self.disabled = True
+        await self.view.after_hook()
+        if n:
+            await interaction.edit_original_response(
+                content=(self.ctx.bot.mgr.e.checkmark + '  ' +
+                         self.ctx.l.config.feed.repo.backlog.fetched.format(n, '<#' + str(self.view.rfi['cid']) + '>')),
+                view=None)
+        else:
+            await interaction.edit_original_response(
+                content=f'{self.ctx.bot.mgr.e.circle_yellow}  {self.ctx.l.config.feed.repo.backlog.no_backlog}',
+                view=None)

--- a/resources/locale/en.locale.json
+++ b/resources/locale/en.locale.json
@@ -533,7 +533,7 @@
         "title": "Your GitBot Config",
         "github": {
           "logged_in_as": "You're logged into GitHub as {0}",
-            "not_logged_in": "You're not logged into GitHub"
+          "not_logged_in": "You're not logged into GitHub"
         },
         "qa": {
           "heading": "**Quick Access:**",
@@ -651,7 +651,24 @@
         "invalid_channel": "{0} is not a valid **channel number/mention** from the list! Send another one, or type `cancel` to exit.",
         "success": "New {0} releases will now be logged in {1}!",
         "cancelled": "Adding a repo to the release feed **cancelled.**",
-        "already_logged": "{0} releases are **already being logged** in {1}!"
+        "already_logged": "{0} releases are **already being logged** in {1}!",
+        "backlog": {
+          "button": {
+            "label": "Fetch some previous releases?"
+          },
+          "select": {
+            "placeholder": "Select a number of releases to fetch",
+            "options": {
+              "one": "Just one",
+              "five": "A few...",
+              "ten": "A whole lot!"
+            }
+          },
+          "how_many": "How many releases would you like to fetch?",
+          "fetching": "Fetching a backlog of available releases...",
+          "fetched": "**Done!** I managed to fetch a backlog of `{0}` releases; they're waiting in {1} right now.",
+          "no_backlog": "The repo doesn't have any releases to fetch, so your feed will be empty for now."
+        }
       },
       "mention": {
         "embed": {

--- a/resources/queries/latest_releases.graphql
+++ b/resources/queries/latest_releases.graphql
@@ -1,0 +1,31 @@
+query($Name: String!, $Owner: String!, $N: Int!) {
+  repository(name: $Name, owner: $Owner) {
+    url
+    usesCustomOpenGraphImage
+    openGraphImageUrl
+    primaryLanguage {
+      color
+    }
+    releases(first: $N, orderBy: {field: CREATED_AT, direction: DESC}) {
+      nodes {
+        isDraft
+        releaseAssets {
+          totalCount
+        }
+        descriptionHTML
+        publishedAt
+        tagName
+        url
+        createdAt
+        isPrerelease
+        isLatest
+        publishedAt
+        name
+        author {
+          login
+          url
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
resolves #396.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces the ability to fetch a backlog of previous releases for a repository. It includes new methods in the GitHub API, UI components for user interaction, and a GraphQL query to support this functionality. Additionally, it enhances existing functions to ensure compatibility with the new features.

* **New Features**:
    - Introduced a new method `get_latest_n_releases_with_repo` in the GitHub API to fetch the latest N releases along with repository details.
    - Added a new UI component `ReleaseFeedBacklogView` to allow users to fetch previous releases for a repository.
    - Implemented a new GraphQL query `latest_releases.graphql` to fetch the latest N releases from a repository.
* **Enhancements**:
    - Enhanced the `transform_latest_release` function to handle missing keys gracefully, ensuring compatibility with backlog fetching.
    - Updated the `handle_feed_repo` method to optionally suppress mentions when processing releases.

<!-- Generated by sourcery-ai[bot]: end summary -->